### PR TITLE
Fix issue with auth_status call

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -163,7 +163,7 @@ class Auth extends Client
     {
         assert('is_string($txid)');
 
-        $method = "POST";
+        $method = "GET";
         $endpoint = "/auth/v2/auth_status";
         $params = array(
             "txid" => $txid,


### PR DESCRIPTION
[Based on documentation for checking auth status](https://duo.com/docs/authapi#/auth_status) API expect **GET** request, not **POST** one.