### PR TITLE
Pass 'auto' device param when using 'auto' factor

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -132,6 +132,7 @@ class Auth extends Client
         }
 
         $params["factor"] = $factor;
+
         if ($factor === "push") {
             assert('array_key_exists("device", $factor_params) && is_string($factor_params["device"])');
             $params["device"] = $factor_params["device"];
@@ -152,6 +153,9 @@ class Auth extends Client
             assert('array_key_exists("device", $factor_params) && is_string($factor_params["device"])');
             $params["device"] = $factor_params["device"];
         } elseif ($factor === "sms") {
+            assert('array_key_exists("device", $factor_params) && is_string($factor_params["device"])');
+            $params["device"] = $factor_params["device"];
+        } elseif ($factor === "auto") {
             assert('array_key_exists("device", $factor_params) && is_string($factor_params["device"])');
             $params["device"] = $factor_params["device"];
         }


### PR DESCRIPTION
Without this change, using 'auto' fails with the response:
```
Array
(
    [response] => Array
        (
            [code] => 40001
            [message] => Missing required request parameters
            [message_detail] => device
            [stat] => FAIL
        )

    [success] => 1
    [http_status_code] => 400
)
```

Afterwards, it works as expected, picking the method that works best for the user.