### PR TITLE
Add automatic request retry/backoff when rate limited

### DIFF
--- a/src/SleepService.php
+++ b/src/SleepService.php
@@ -1,0 +1,7 @@
+<?php
+namespace DuoAPI;
+
+interface SleepService
+{
+    public function sleep($seconds);
+}

--- a/src/USleepService.php
+++ b/src/USleepService.php
@@ -1,0 +1,10 @@
+<?php
+namespace DuoAPI;
+
+class USleepService implements SleepService
+{
+    public function sleep($seconds)
+    {
+        usleep($seconds * 1000000);
+    }
+}

--- a/tests/Unit/AdminTest.php
+++ b/tests/Unit/AdminTest.php
@@ -29,6 +29,7 @@ class AdminTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         return $successful_integrations_response;
@@ -71,6 +72,7 @@ class AdminTest extends BaseTest
                 ]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ],[
             "response" => json_encode([
                 "stat" => "OK",
@@ -79,6 +81,7 @@ class AdminTest extends BaseTest
                 ]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ]];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = true);
@@ -132,6 +135,7 @@ class AdminTest extends BaseTest
                 ]]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = false);
@@ -153,6 +157,7 @@ class AdminTest extends BaseTest
                 ]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ],[
             "response" => json_encode([
                 "stat" => "OK",
@@ -161,6 +166,7 @@ class AdminTest extends BaseTest
                 ]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ]];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = true);
@@ -213,6 +219,7 @@ class AdminTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = false);
@@ -256,6 +263,7 @@ class AdminTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = false);
@@ -274,6 +282,7 @@ class AdminTest extends BaseTest
                 "response" => "",
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = false);
@@ -292,6 +301,7 @@ class AdminTest extends BaseTest
                 "response" => "",
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = false);
@@ -310,6 +320,7 @@ class AdminTest extends BaseTest
                 "response" => "",
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = false);
@@ -347,6 +358,7 @@ class AdminTest extends BaseTest
                 ]],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = false);
@@ -368,6 +380,7 @@ class AdminTest extends BaseTest
                 ]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ],[
             "response" => json_encode([
                 "stat" => "OK",
@@ -376,6 +389,7 @@ class AdminTest extends BaseTest
                 ]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ]];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = true);
@@ -400,6 +414,7 @@ class AdminTest extends BaseTest
                 ]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $admin_client = self::getMockedClient("Admin", $successful_response, $paged = false);

--- a/tests/Unit/AuthTest.php
+++ b/tests/Unit/AuthTest.php
@@ -33,6 +33,7 @@ class AuthTest extends BaseTest
                 ]
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         return $successful_preauth_response;
@@ -48,6 +49,7 @@ class AuthTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $auth_client = self::getMockedClient("Auth", $successful_ping_response, $paged = false);
@@ -68,6 +70,7 @@ class AuthTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $auth_client = self::getMockedClient("Auth", $successful_check_response, $paged = false);
@@ -92,6 +95,7 @@ class AuthTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $auth_client = self::getMockedClient("Auth", $successful_enroll_response, $paged = false);
@@ -109,6 +113,7 @@ class AuthTest extends BaseTest
                 "response" => "success",
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $auth_client = self::getMockedClient("Auth", $successful_enroll_status_response, $paged = false);
@@ -170,6 +175,7 @@ class AuthTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $auth_client = self::getMockedClient("Auth", $successful_auth_response, $paged = false);
@@ -192,6 +198,7 @@ class AuthTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $auth_client = self::getMockedClient("Auth", $successful_auth_status_response, $paged = false);
@@ -260,6 +267,7 @@ class AuthTest extends BaseTest
         $non_json_response = [
             "response" => "NON JSON STRING",
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         $auth_client = self::getMockedClient("Auth", $non_json_response, $paged = false);

--- a/tests/Unit/FrameTest.php
+++ b/tests/Unit/FrameTest.php
@@ -13,6 +13,7 @@ class FrameTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         return $successful_init_response;
@@ -30,6 +31,7 @@ class FrameTest extends BaseTest
                 ],
             ]),
             "success" => true,
+            "http_status_code" => 200,
         ];
 
         return $successful_init_response;


### PR DESCRIPTION
If the request is rate limited, this library will now sleep for
a bit and then try again. We use an exponential backoff, so the
request should sleep for 1 second, then 2, then 4, 8, 16, and max
out at 32 seconds.