### PR TITLE
Add optional timeout parameter for 2FA auths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - '7.1'
     - '7.2'
     - '7.3'
+    - '7.4'
 addons:
     apt:
         packages:

--- a/README.md
+++ b/README.md
@@ -66,14 +66,9 @@ array(2) {
 
 ```
 $ ./vendor/bin/phpunit -c phpunit.xml
-PHPUnit 5.3.2 by Sebastian Bergmann and contributors.
-
-..............................                                    30 / 30 (100%)
-
-Time: 1.18 seconds, Memory: 6.00Mb
-
-OK (30 tests, 48 assertions)
 ```
+
+Note that the tests in `tests/SSL/SSLTest.php` require `stunnel3`.
 
 # Linting
 

--- a/tests/Unit/AuthTest.php
+++ b/tests/Unit/AuthTest.php
@@ -39,6 +39,22 @@ class AuthTest extends BaseTest
         return $successful_preauth_response;
     }
 
+    protected static function getSuccessfulAuthResponse()
+    {
+        return [
+            "response" => json_encode([
+                "stat" => "OK",
+                "response" => [
+                    "result" => "waiting",
+                    "status" => "pushed",
+                    "status_msg" => "Pushed a login request to your phone...",
+                ],
+            ]),
+            "success" => true,
+            "http_status_code" => 200,
+        ];
+    }
+
     protected static function getSuccessfulAuthStatusResponse()
     {
         return [
@@ -181,25 +197,103 @@ class AuthTest extends BaseTest
 
     public function testAuthCall()
     {
-        $successful_auth_response = [
-            "response" => json_encode([
-                "stat" => "OK",
-                "response" => [
-                    "result" => "allow",
-                    "status" => "allow",
-                    "status_msg" => "Success. Logging you in...",
-                ],
-            ]),
-            "success" => true,
-            "http_status_code" => 200,
-        ];
-
+        $successful_auth_response = self::getSuccessfulAuthResponse();
         $auth_client = self::getMockedClient("Auth", $successful_auth_response, $paged = false);
+
+        // Set up the expectation that the auth call will be made with the
+        // default increased timeout for auths.
+        $auth_client->requester->expects($this->once())
+            ->method('options')
+            ->with($this->equalTo([
+                "timeout" => 60,
+            ]));
 
         $result = $auth_client->auth('testuser', 'passcode', ['passcode' => '123']);
 
         $this->assertEquals($result["response"]["stat"], "OK");
         $this->assertTrue($result["success"]);
+
+        // Make sure the original requester timeout got restored when the
+        // auth was done
+        $this->assertEquals($auth_client->options["timeout"], 10);
+    }
+
+    public function testAuthCallTimeout()
+    {
+        $successful_auth_response = self::getSuccessfulAuthResponse();
+        $auth_client = self::getMockedClient("Auth", $successful_auth_response, $paged = false);
+
+        $test_timeout = 120;
+        // Set up the expectation that the auth call will be made with the
+        // timeout passed to auth()
+        $auth_client->requester->expects($this->once())
+            ->method('options')
+            ->with($this->equalTo([
+                "timeout" => $test_timeout,
+            ]));
+
+
+        $result = $auth_client->auth('testuser', 'passcode', ['passcode' => '123'], null, false, true, $test_timeout);
+
+        $this->assertEquals($result["response"]["stat"], "OK");
+        $this->assertTrue($result["success"]);
+
+        // Make sure the original requester timeout got restored when the
+        // auth was done
+        $this->assertEquals($auth_client->options["timeout"], 10);
+    }
+
+    public function testAuthCallNoRequesterTimeout()
+    {
+        $successful_auth_response = self::getSuccessfulAuthResponse();
+        $auth_client = self::getMockedClient("Auth", $successful_auth_response, $paged = false);
+
+        // Set up the expectation that the auth call will be made with the
+        // default increased timeout for auths.
+        $auth_client->requester->expects($this->once())
+            ->method('options')
+            ->with($this->equalTo([
+                "timeout" => 60,
+            ]));
+
+        // Test that we still use the default timeout for the auth() method
+        // even if someone blows away the timeout on the requester for some reason
+        $auth_client->options = [];
+        $result = $auth_client->auth('testuser', 'passcode', ['passcode' => '123']);
+
+        $this->assertEquals($result["response"]["stat"], "OK");
+        $this->assertTrue($result["success"]);
+
+        // Make sure the timeout got removed from the requester options when
+        // the auth was done. 
+        $this->assertEquals($auth_client->options, []);
+
+    }
+
+    public function testAuthCallLargerRequesterTimeout()
+    {
+        $successful_auth_response = self::getSuccessfulAuthResponse();
+        $auth_client = self::getMockedClient("Auth", $successful_auth_response, $paged = false);
+
+        $test_timeout = 300;
+        $auth_client->setRequesterOption("timeout", $test_timeout);
+
+        // Set up the expectation that the auth call will be made with the
+        // timeout on the requester since it's larger than auth()'s timeout
+        // parameter
+        $auth_client->requester->expects($this->once())
+            ->method('options')
+            ->with($this->equalTo([
+                "timeout" => $test_timeout,
+            ]));
+
+        $result = $auth_client->auth('testuser', 'passcode', ['passcode' => '123']);
+
+        $this->assertEquals($result["response"]["stat"], "OK");
+        $this->assertTrue($result["success"]);
+
+        // The timeout on the requester should not have changed
+        $this->assertEquals($auth_client->options["timeout"], $test_timeout);
     }
 
     public function testAuthStatusCall()

--- a/tests/Unit/AuthTest.php
+++ b/tests/Unit/AuthTest.php
@@ -39,6 +39,22 @@ class AuthTest extends BaseTest
         return $successful_preauth_response;
     }
 
+    protected static function getSuccessfulAuthStatusResponse()
+    {
+        return [
+            "response" => json_encode([
+                "stat" => "OK",
+                "response" => [
+                    "result" => "waiting",
+                    "status" => "pushed",
+                    "status_msg" => "Pushed a login request to your phone...",
+                ],
+            ]),
+            "success" => true,
+            "http_status_code" => 200,
+        ];
+    }
+
     public function testPingCall()
     {
         $successful_ping_response = [
@@ -188,18 +204,7 @@ class AuthTest extends BaseTest
 
     public function testAuthStatusCall()
     {
-        $successful_auth_status_response = [
-            "response" => json_encode([
-                "stat" => "OK",
-                "response" => [
-                    "result" => "waiting",
-                    "status" => "pushed",
-                    "status_msg" => "Pushed a login request to your phone...",
-                ],
-            ]),
-            "success" => true,
-            "http_status_code" => 200,
-        ];
+        $successful_auth_status_response = self::getSuccessfulAuthStatusResponse();
 
         $auth_client = self::getMockedClient("Auth", $successful_auth_status_response, $paged = false);
 
@@ -211,28 +216,22 @@ class AuthTest extends BaseTest
 
     public function testAuthStatusHttpArguments()
     {
-        $curl_mock = $this->mocked_curl_requester;
-
-        $txid = 'IDIDIDIDIDIDIDID';
+        $successful_auth_status_response = self::getSuccessfulAuthStatusResponse();
+        $auth_client = self::getMockedClient("Auth", $successful_auth_status_response, $paged = false);
 
         // The actual test being performed is in the 'equalTo(...)' calls.
         $host = "api-duo.example.com";
-        $curl_mock->expects($this->once())
-                  ->method('execute')
-                  ->with(
-                      $this->equalTo("https://" . $host . "/auth/v2/auth_status?txid=" . $txid),
-                      $this->equalTo('GET'),
-                      $this->anything(),
-                      $this->anything()
-                  );
+        $txid = 'IDIDIDIDIDIDIDID';
+        $auth_client->requester->expects($this->once())
+            ->method('execute')
+            ->with(
+                $this->equalTo("https://" . $host . "/auth/v2/auth_status?txid=" . $txid),
+                $this->equalTo('GET'),
+                $this->anything(),
+                $this->anything()
+            );
 
-        $duo = new \DuoAPI\Auth(
-            "IKEYIKEYIKEYIKEYIKEY",
-            "SKEYSKEYSKEYSKEYSKEYSKEYSKEYSKEYSKEYSKEY",
-            $host,
-            $curl_mock
-        );
-        $duo->auth_status($txid);
+        $auth_client->auth_status($txid);
     }
 
     public function testLogoHttpArguments()


### PR DESCRIPTION
Adds an optional timeout parameter to the auth method for the Auth API. This allows for setting a timeout that persists only for that auth, which is useful for making sure there's enough time to complete secondary authentication.  