### PR TITLE
PHP API now includes user agent string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,11 @@
     "support": {
         "email": "support@duosecurity.com"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    },
     "autoload": {
         "psr-4": {
             "DuoAPI\\": "src/"

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@ namespace DuoAPI;
 
 use DateTime;
 
+const VERSION = "1.0.0";
 const INITIAL_BACKOFF_SECONDS = 1;
 const MAX_BACKOFF_SECONDS = 32;
 const BACKOFF_FACTOR = 2;
@@ -151,6 +152,7 @@ class Client
         $headers = [];
         $headers["Date"] = $now;
         $headers["Host"] = $this->host;
+        $headers["User-Agent"] = "duo_api_php/" . VERSION;
         $headers["Authorization"] = self::signParameters(
             $method,
             $this->host,


### PR DESCRIPTION
In order to better identify which duo library is being used to make requests we are now including a customer user agent string in requests.