### PR TITLE
Fixed lingering HTTP method state

### DIFF
--- a/src/CurlRequester.php
+++ b/src/CurlRequester.php
@@ -67,8 +67,10 @@ class CurlRequester implements Requester
         if ($method === "POST") {
             curl_setopt($this->ch, CURLOPT_POST, true);
             curl_setopt($this->ch, CURLOPT_POSTFIELDS, $body);
+            curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, null);
         } elseif ($method === "GET") {
             curl_setopt($this->ch, CURLOPT_HTTPGET, true);
+            curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, null);
         } else {
             curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, $method);
         }


### PR DESCRIPTION
This change ensures that the HTTP method set via CURLOPT_CUSTOMREQUEST is unset when attempting to change the method via CURLOPT_POST or CURLOPT_HTTPGET. If this is not done before any subsequent curl_exec() calls where a CURLOPT_POST and CURLOPT_HTTPGET is desired, the previous CURLOPT_CUSTOMREQUEST setting will quietly continue to override them without error or warning.