### PR TITLE
Ensure consecutive request calls overwrite all the request options

### DIFF
--- a/src/CurlRequester.php
+++ b/src/CurlRequester.php
@@ -3,6 +3,8 @@ namespace DuoAPI;
 
 class CurlRequester implements Requester
 {
+    /** @var resource */
+    protected $ch;
 
     public function __construct()
     {
@@ -11,7 +13,7 @@ class CurlRequester implements Requester
 
     public function __destruct()
     {
-        if (property_exists($this, 'ch')) {
+        if (is_resource($this->ch)) {
             curl_close($this->ch);
         }
     }
@@ -63,17 +65,10 @@ class CurlRequester implements Requester
 
         curl_setopt($this->ch, CURLOPT_URL, $url);
         curl_setopt($this->ch, CURLOPT_HTTPHEADER, $headers);
-
-        if ($method === "POST") {
-            curl_setopt($this->ch, CURLOPT_POST, true);
-            curl_setopt($this->ch, CURLOPT_POSTFIELDS, $body);
-            curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, null);
-        } elseif ($method === "GET") {
-            curl_setopt($this->ch, CURLOPT_HTTPGET, true);
-            curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, null);
-        } else {
-            curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, $method);
-        }
+        curl_setopt($this->ch, CURLOPT_POSTFIELDS, $body);
+        curl_setopt($this->ch, CURLOPT_CUSTOMREQUEST, $method);
+        curl_setopt($this->ch, CURLOPT_POST, $method === 'POST');
+        curl_setopt($this->ch, CURLOPT_HTTPGET, $method === 'GET');
 
         $result = curl_exec($this->ch);
 

--- a/src/FileRequester.php
+++ b/src/FileRequester.php
@@ -98,6 +98,8 @@ class FileRequester implements Requester
 
         if ($method === "POST") {
             $this->http_options['http']['content'] = $body;
+        } else {
+            unset($this->http_options['http']['content']);
         }
 
         $context = stream_context_create($this->http_options);


### PR DESCRIPTION
There is a bug in the class DuoAPI\CurlRequester: since it is using the same curl resource (the property "ch") for multiple (consecutive) requests, it is supposed to overwrite all the curl options. Otherwise, a request with method DELETE followed by a request with method POST will fail.

The reason is that when a request with method DELETE is done, it sets the option CURLOPT_CUSTOMREQUEST with DELETE. But when the consecutive request with method POST is done, it only sets the option CURLOPT_POST with true, but CURLOPT_CUSTOMREQUEST is kept with the value from the previous request (DELETE).

To fix it, I prepared a change to ensure all the curl options are overwritten for each new request.

A similar problem may occur in the class DuoAPI\FileRequester, when a request is made using POST (with data to post), then a second request is made without any data to post.