### PR TITLE
Restrict certificates to list of trusted CAs

### DIFF
--- a/src/CurlRequester.php
+++ b/src/CurlRequester.php
@@ -1,6 +1,8 @@
 <?php
 namespace DuoAPI;
 
+define('DEFAULT_CA_CERTS', __DIR__."/ca_certs.pem");
+
 class CurlRequester implements Requester
 {
 
@@ -40,6 +42,10 @@ class CurlRequester implements Requester
         foreach ($curl_options as $key => $value) {
             $curl_options[$key] = $options[$value];
         }
+
+        if (!isset($curl_options[CURLOPT_CAINFO])) {
+            $curl_options[CURLOPT_CAINFO] = DEFAULT_CA_CERTS;
+        };
 
         // Mandatory configuration options
         $curl_options[CURLOPT_RETURNTRANSFER] = 1;

--- a/src/CurlRequester.php
+++ b/src/CurlRequester.php
@@ -47,6 +47,10 @@ class CurlRequester implements Requester
             $curl_options[CURLOPT_CAINFO] = DEFAULT_CA_CERTS;
         };
 
+        if ($curl_options[CURLOPT_CAINFO] == "IGNORE") {
+            unset($curl_options[CURLOPT_CAINFO]);
+        };
+
         // Mandatory configuration options
         $curl_options[CURLOPT_RETURNTRANSFER] = 1;
         $curl_options[CURLOPT_FOLLOWLOCATION] = 1;


### PR DESCRIPTION
In order to improve the security posture of API clients we're providing a list of trusted certificates with the API library which will be trusted by default.