### PR TITLE
PHP API now includes user agent string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,11 @@
     "support": {
         "email": "support@duosecurity.com"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.1.x-dev"
+        }
+    },
     "autoload": {
         "psr-4": {
             "DuoAPI\\": "src/"

--- a/src/Client.php
+++ b/src/Client.php
@@ -3,6 +3,7 @@ namespace DuoAPI;
 
 use DateTime;
 
+const VERSION = "1.1.0";
 const INITIAL_BACKOFF_SECONDS = 1;
 const MAX_BACKOFF_SECONDS = 32;
 const BACKOFF_FACTOR = 2;
@@ -159,6 +160,7 @@ class Client
         $headers = [];
         $headers["Date"] = $now;
         $headers["Host"] = $this->host;
+        $headers["User-Agent"] = "duo_api_php/" . VERSION;
         $headers["Authorization"] = self::signParameters(
             $method,
             $this->host,

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -317,4 +317,29 @@ class ClientTest extends BaseTest
             32 + ($this->random_numbers[5] / 1000),
         ], ($this->mock_sleep_svc->sleep_calls));
     }
+
+    public function testUserAgent()
+    {
+        $success_resp =             [
+            "success" => true,
+            "response" => "not rate limited",
+            "http_status_code" => 200,
+        ];
+
+        $response = [$success_resp];
+
+        $client = self::getMockedClient("Client", $response, $paged = true);
+        $this->mocked_curl_requester->method('execute')->with(
+            $this->anything),
+            $this->anything(),
+            $this->callback(function($headers) {
+                $version = "duo_api_php/" . \DuoAPI\VERSION;
+                $this->assertArrayHasKey("User-Agent", $headers);
+                $this->assertEquals($headers["User-Agent"], $version);
+                return true;
+            }),
+            $this->anything()
+        );
+        $response = $client->apiCall("GET", "/foo/bar", []);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a user-agent string to requests made with duo_api_php

## Motivation and Context
This allows Duo to track the usage and popularity of certain SDKs for setting priorities.

## How Has This Been Tested?
Unit test added to check for header


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
