### PR TITLE
Update integrations endpoint to v3

### DIFF
--- a/src/Admin.php
+++ b/src/Admin.php
@@ -188,7 +188,7 @@ class Admin extends Client
     public function integrations($ikey = null)
     {
         $method = "GET";
-        $endpoint = "/admin/v1/integrations";
+        $endpoint = "/admin/v3/integrations";
         $params = [];
 
         if ($ikey) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This updates the only reference to `/admin/v1/integrations` to `/admin/v3/integrations` similar to https://github.com/duosecurity/duo_client_python/pull/282. It also includes changes to update to canonicalization v5.

## Description
Updates the `/admin/v1/integrations` reference to `v3`.

Because the `v3` endpoints require canonicalization 5, the larger change in this PR is updating the canonicalization to 5.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The v3 integrations endpoints add a new `user_access` field and change the behavior of the `groups_allowed` field.

Previously the `groups_allowed` field by itself determined which users could authenticate with the application as described [here](https://duo.com/docs/adminapi#integrations). Now a third state has been added which allows no users to authenticate.

Because of that, the `user_access` field has been added to express this more cleanly, and `groups_allowed` can only be provided if `user_access == "PERMITTED_GROUPS"`.

## How Has This Been Tested?

- Verified `admin/v3/integrations` endpoint is working as expected
- Regression tested some old V1 endpoints (`POST admin/v1/groups`, `POST admin/v1/groups/:gkey`, `POST admin/v1/users`

https://gist.github.com/ckeif-duo/f86490d5380f6c57bfde4031e02e6795

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
