### PR TITLE
Handle empty parameters in POST call better

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -214,7 +214,7 @@ class Client
         $headers = [];
         if (in_array($method, ["POST", "PUT", "PATCH"], true)) {
             ksort($params);
-            $body = json_encode($params);
+            $body = empty($params) ? "{}" : json_encode($params);
             $params = [];
             $headers["Content-Type"] = "application/json";
             $uri = $path;


### PR DESCRIPTION
PHP is encoding the empty parameters as an empty JSON list rather than the empty JSON object we need.  Explicitly test for empty parameters.

## Motivation and Context
Prevent API call errors.  Fixes #41 

## How Has This Been Tested?
Will test manually

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
