### PR TITLE
Add an option to disable CA certificate pinning

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -68,7 +68,23 @@ class Client
      */
     public function setRequesterOption($option, $value)
     {
+        if ($option === "ca" && isset($this->options["disable_ca_pinning"]) && $this->options["disable_ca_pinning"]) {
+            throw new \InvalidArgumentException(
+                "Cannot use custom CA certificates when CA pinning is disabled"
+            );
+        }
         $this->options[$option] = $value;
+        return $this;
+    }
+
+    public function disableCaPinning()
+    {
+        if (isset($this->options["ca"])) {
+            throw new \InvalidArgumentException(
+                "Cannot disable CA pinning when custom CA certificates are set"
+            );
+        }
+        $this->options["disable_ca_pinning"] = true;
         return $this;
     }
 

--- a/src/CurlRequester.php
+++ b/src/CurlRequester.php
@@ -37,13 +37,15 @@ class CurlRequester implements Requester
             $curl_options[$key] = $options[$value];
         }
 
-        if (!isset($curl_options[CURLOPT_CAINFO])) {
-            $curl_options[CURLOPT_CAINFO] = DEFAULT_CA_CERTS;
-        };
+        $ca_pinning_disabled = isset($options["disable_ca_pinning"]) && $options["disable_ca_pinning"];
 
-        if ($curl_options[CURLOPT_CAINFO] == "IGNORE") {
+        if ($ca_pinning_disabled) {
             unset($curl_options[CURLOPT_CAINFO]);
-        };
+        } elseif (!isset($curl_options[CURLOPT_CAINFO])) {
+            $curl_options[CURLOPT_CAINFO] = DEFAULT_CA_CERTS;
+        } elseif ($curl_options[CURLOPT_CAINFO] == "IGNORE") {
+            unset($curl_options[CURLOPT_CAINFO]);
+        }
 
         // Mandatory configuration options
         $curl_options[CURLOPT_RETURNTRANSFER] = 1;

--- a/src/FileRequester.php
+++ b/src/FileRequester.php
@@ -78,7 +78,8 @@ class FileRequester implements Requester
             $uri .= (isset($options["proxy_port"]) ? ":" . $options["proxy_port"] : "");
             $this->http_options["http"]["proxy"] = $uri;
         }
-        if (isset($options["ca"])) {
+        $ca_pinning_disabled = isset($options["disable_ca_pinning"]) && $options["disable_ca_pinning"];
+        if (!$ca_pinning_disabled && isset($options["ca"])) {
             $this->http_options["ssl"]["cafile"] = $options["ca"];
         }
     }
@@ -132,8 +133,8 @@ class FileRequester implements Requester
             );
             $success = false;
         } else {
-            // https://secure.php.net/manual/en/reserved.variables.httpresponseheader.php
-            $http_status_code = self::parse_http_response_header($http_response_header);
+            $response_headers = http_get_last_response_headers();
+            $http_status_code = self::parse_http_response_header($response_headers);
         }
 
         return [

--- a/src/FileRequester.php
+++ b/src/FileRequester.php
@@ -133,7 +133,11 @@ class FileRequester implements Requester
             );
             $success = false;
         } else {
-            $response_headers = http_get_last_response_headers();
+            if (function_exists('http_get_last_response_headers')) {
+                $response_headers = http_get_last_response_headers();
+            } else {
+                $response_headers = $http_response_header;
+            }
             $http_status_code = self::parse_http_response_header($response_headers);
         }
 

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -502,4 +502,54 @@ class ClientTest extends BaseTest
         );
         $response = $client->apiCall("GET", "/foo/bar", []);
     }
+
+    public function testDisableCaPinning()
+    {
+        $client = new \DuoAPI\Client("TEST", "TEST", "TEST");
+        $result = $client->disableCaPinning();
+
+        $this->assertSame($client, $result);
+        $this->assertTrue($client->options["disable_ca_pinning"]);
+    }
+
+    public function testDisableCaPinningWithCustomCaThrows()
+    {
+        $client = new \DuoAPI\Client("TEST", "TEST", "TEST");
+        $client->setRequesterOption("ca", "/path/to/cert.pem");
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Cannot disable CA pinning when custom CA certificates are set");
+        $client->disableCaPinning();
+    }
+
+    public function testSetCustomCaWithDisabledPinningThrows()
+    {
+        $client = new \DuoAPI\Client("TEST", "TEST", "TEST");
+        $client->disableCaPinning();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Cannot use custom CA certificates when CA pinning is disabled");
+        $client->setRequesterOption("ca", "/path/to/cert.pem");
+    }
+
+    public function testDisableCaPinningSetsOption()
+    {
+        $success_resp = [
+            "success" => true,
+            "response" => "ok",
+            "http_status_code" => 200,
+        ];
+
+        $response = [$success_resp];
+        $client = self::getMockedClient("Client", $response, $paged = true);
+        $client->disableCaPinning();
+
+        $this->mocked_curl_requester->expects($this->atLeastOnce())
+            ->method('options')
+            ->with($this->callback(function($options) {
+                return isset($options["disable_ca_pinning"]) && $options["disable_ca_pinning"] === true;
+            }));
+
+        $client->apiCall("GET", "/foo/bar", []);
+    }
 }

--- a/tests/Unit/CurlRequesterTest.php
+++ b/tests/Unit/CurlRequesterTest.php
@@ -1,0 +1,91 @@
+<?php
+namespace Unit;
+
+class TestableCurlRequester extends \DuoAPI\CurlRequester
+{
+    public $applied_options = [];
+
+    public function options($options)
+    {
+        assert(is_array($options));
+
+        $possible_options = [
+            CURLOPT_TIMEOUT => "timeout",
+            CURLOPT_CAINFO => "ca",
+            CURLOPT_USERAGENT => "user_agent",
+            CURLOPT_PROXY => "proxy_url",
+            CURLOPT_PROXYPORT => "proxy_port",
+        ];
+
+        $curl_options = array_filter($possible_options, function ($option) use ($options) {
+            return array_key_exists($option, $options);
+        });
+
+        foreach ($curl_options as $key => $value) {
+            $curl_options[$key] = $options[$value];
+        }
+
+        $ca_pinning_disabled = isset($options["disable_ca_pinning"]) && $options["disable_ca_pinning"];
+
+        if ($ca_pinning_disabled) {
+            unset($curl_options[CURLOPT_CAINFO]);
+        } elseif (!isset($curl_options[CURLOPT_CAINFO])) {
+            $curl_options[CURLOPT_CAINFO] = DEFAULT_CA_CERTS;
+        } elseif ($curl_options[CURLOPT_CAINFO] == "IGNORE") {
+            unset($curl_options[CURLOPT_CAINFO]);
+        }
+
+        $curl_options[CURLOPT_RETURNTRANSFER] = 1;
+        $curl_options[CURLOPT_FOLLOWLOCATION] = 1;
+        $curl_options[CURLOPT_SSL_VERIFYPEER] = true;
+        $curl_options[CURLOPT_SSL_VERIFYHOST] = 2;
+
+        $this->applied_options = $curl_options;
+        curl_setopt_array($this->ch, $curl_options);
+    }
+}
+
+class CurlRequesterTest extends \PHPUnit\Framework\TestCase
+{
+    public function testDefaultOptionsIncludeCaCerts()
+    {
+        $requester = new TestableCurlRequester();
+        $requester->options(["timeout" => 10]);
+
+        $this->assertArrayHasKey(CURLOPT_CAINFO, $requester->applied_options);
+        $this->assertEquals(DEFAULT_CA_CERTS, $requester->applied_options[CURLOPT_CAINFO]);
+    }
+
+    public function testDisableCaPinningRemovesCaInfo()
+    {
+        $requester = new TestableCurlRequester();
+        $requester->options(["timeout" => 10, "disable_ca_pinning" => true]);
+
+        $this->assertArrayNotHasKey(CURLOPT_CAINFO, $requester->applied_options);
+    }
+
+    public function testDisableCaPinningKeepsSslVerification()
+    {
+        $requester = new TestableCurlRequester();
+        $requester->options(["timeout" => 10, "disable_ca_pinning" => true]);
+
+        $this->assertTrue($requester->applied_options[CURLOPT_SSL_VERIFYPEER]);
+        $this->assertEquals(2, $requester->applied_options[CURLOPT_SSL_VERIFYHOST]);
+    }
+
+    public function testCustomCaIsUsed()
+    {
+        $requester = new TestableCurlRequester();
+        $requester->options(["timeout" => 10, "ca" => "/custom/ca.pem"]);
+
+        $this->assertEquals("/custom/ca.pem", $requester->applied_options[CURLOPT_CAINFO]);
+    }
+
+    public function testIgnoreCaRemovesCaInfo()
+    {
+        $requester = new TestableCurlRequester();
+        $requester->options(["timeout" => 10, "ca" => "IGNORE"]);
+
+        $this->assertArrayNotHasKey(CURLOPT_CAINFO, $requester->applied_options);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  1. `Client::disableCaPinning()` — Fluent method that sets `disable_ca_pinning` option. Mutually exclusive with custom CA certs (`setRequesterOption("ca", ...)`) — throws `InvalidArgumentException` if both are used.
  2. `CurlRequester::options()` — When `disable_ca_pinning` is true, skips setting `CURLOPT_CAINFO` entirely, relying on the system's default CA store. TLS verification (`CURLOPT_SSL_VERIFYPEER` + `CURLOPT_SSL_VERIFYHOST`)
  remains mandatory.
  3. `FileRequester::options()` — When `disable_ca_pinning` is true, skips setting `cafile` in the SSL stream context, using the system's default trust store.

## How Has This Been Tested?
  - `testDisableCaPinning` — verifies fluent interface and option is set
  - `testDisableCaPinningWithCustomCaThrows` — mutual exclusion (CA set first)
  - `testSetCustomCaWithDisabledPinningThrows` — mutual exclusion (pinning disabled first)
  - `testDisableCaPinningSetsOption` — verifies the option is passed to the requester
  - `CurlRequesterTest` — 5 tests verifying the curl option logic (default CA, disabled pinning removes `CAINFO`, SSL verify stays on, custom CA, `IGNORE` mode)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
