### PR TITLE
Add appendToUserAgent() method to Client class

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -22,6 +22,7 @@ class Client
     public $paging;
     public $options;
     public $sleep_service;
+    private $user_agent_extension = "";
 
     public function __construct(
         $ikey,
@@ -86,6 +87,12 @@ class Client
             );
         }
         $this->options["disable_ca_pinning"] = true;
+        return $this;
+    }
+
+    public function appendToUserAgent(string $user_agent_extension)
+    {
+        $this->user_agent_extension = trim($user_agent_extension);
         return $this;
     }
 
@@ -242,9 +249,13 @@ class Client
 
         $headers["Date"] = $now;
         $ca_pinning_status = (!empty($this->options["disable_ca_pinning"])) ? "disabled" : "enabled";
-        $headers["User-Agent"] = "duo_api_php/" . VERSION
+        $user_agent = "duo_api_php/" . VERSION
             . " ca_bundle/" . CA_BUNDLE_VERSION
             . " (ca_pinning=" . $ca_pinning_status . ")";
+        if (!empty($this->user_agent_extension)) {
+            $user_agent .= " " . $this->user_agent_extension;
+        }
+        $headers["User-Agent"] = $user_agent;
         $headers["Authorization"] = self::signParameters(
             $method,
             $this->host,

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -533,6 +533,119 @@ class ClientTest extends BaseTest
         $response = $client->apiCall("GET", "/foo/bar", []);
     }
 
+    public function testUserAgentWithExtension()
+    {
+        $success_resp = [
+            "success" => true,
+            "response" => "not rate limited",
+            "http_status_code" => 200,
+        ];
+
+        $response = [$success_resp];
+
+        $client = self::getMockedClient("Client", $response, $paged = true);
+        $client->appendToUserAgent("MyApp/1.0");
+        $this->mocked_curl_requester->method('execute')->with(
+            $this->anything(),
+            $this->anything(),
+            $this->callback(function($headers) {
+                $expected = "duo_api_php/" . \DuoAPI\VERSION
+                    . " ca_bundle/" . \DuoAPI\CA_BUNDLE_VERSION
+                    . " (ca_pinning=enabled) MyApp/1.0";
+                $this->assertArrayHasKey("User-Agent", $headers);
+                $this->assertEquals($expected, $headers["User-Agent"]);
+                return true;
+            }),
+            $this->anything()
+        );
+        $response = $client->apiCall("GET", "/foo/bar", []);
+    }
+
+    public function testUserAgentWithWhitespaceExtension()
+    {
+        $success_resp = [
+            "success" => true,
+            "response" => "not rate limited",
+            "http_status_code" => 200,
+        ];
+
+        $response = [$success_resp];
+
+        $client = self::getMockedClient("Client", $response, $paged = true);
+        $client->appendToUserAgent("  ");
+        $this->mocked_curl_requester->method('execute')->with(
+            $this->anything(),
+            $this->anything(),
+            $this->callback(function($headers) {
+                $expected = "duo_api_php/" . \DuoAPI\VERSION
+                    . " ca_bundle/" . \DuoAPI\CA_BUNDLE_VERSION
+                    . " (ca_pinning=enabled)";
+                $this->assertArrayHasKey("User-Agent", $headers);
+                $this->assertEquals($expected, $headers["User-Agent"]);
+                return true;
+            }),
+            $this->anything()
+        );
+        $response = $client->apiCall("GET", "/foo/bar", []);
+    }
+
+    public function testUserAgentExtensionIsTrimmed()
+    {
+        $success_resp = [
+            "success" => true,
+            "response" => "not rate limited",
+            "http_status_code" => 200,
+        ];
+
+        $response = [$success_resp];
+
+        $client = self::getMockedClient("Client", $response, $paged = true);
+        $client->appendToUserAgent("  MyApp/1.0  ");
+        $this->mocked_curl_requester->method('execute')->with(
+            $this->anything(),
+            $this->anything(),
+            $this->callback(function($headers) {
+                $expected = "duo_api_php/" . \DuoAPI\VERSION
+                    . " ca_bundle/" . \DuoAPI\CA_BUNDLE_VERSION
+                    . " (ca_pinning=enabled) MyApp/1.0";
+                $this->assertArrayHasKey("User-Agent", $headers);
+                $this->assertEquals($expected, $headers["User-Agent"]);
+                return true;
+            }),
+            $this->anything()
+        );
+        $response = $client->apiCall("GET", "/foo/bar", []);
+    }
+
+    public function testAppendToUserAgentOverwritesPrevious()
+    {
+        $success_resp = [
+            "success" => true,
+            "response" => "not rate limited",
+            "http_status_code" => 200,
+        ];
+
+        $response = [$success_resp];
+
+        $client = self::getMockedClient("Client", $response, $paged = true);
+        $client->appendToUserAgent("First/1.0");
+        $client->appendToUserAgent("Second/2.0");
+        $this->mocked_curl_requester->method('execute')->with(
+            $this->anything(),
+            $this->anything(),
+            $this->callback(function($headers) {
+                $expected = "duo_api_php/" . \DuoAPI\VERSION
+                    . " ca_bundle/" . \DuoAPI\CA_BUNDLE_VERSION
+                    . " (ca_pinning=enabled) Second/2.0";
+                $this->assertArrayHasKey("User-Agent", $headers);
+                $this->assertEquals($expected, $headers["User-Agent"]);
+                return true;
+            }),
+            $this->anything()
+        );
+        $response = $client->apiCall("GET", "/foo/bar", []);
+    }
+
     public function testDisableCaPinning()
     {
         $client = new \DuoAPI\Client("TEST", "TEST", "TEST");


### PR DESCRIPTION
## Summary

- Adds `appendToUserAgent(string $extension)` to `Client`, allowing callers to append custom identifiers to the User-Agent header sent with API requests
- Matches the pattern established in [duo_universal_php](https://github.com/duosecurity/duo_universal_php) for consistency across Duo PHP SDKs
- Uses a fluent interface (`return $this`) consistent with `setRequesterOption()` and `disableCaPinning()`

## Design notes

- **Last-call-wins semantics:** Subsequent calls to `appendToUserAgent()` overwrite the previous value rather than concatenating. This keeps the UA string predictable and matches the `duo_universal_php` behavior.
- **Trimming:** The extension is trimmed before storage. If the result is empty/whitespace-only, nothing is appended (no trailing space in the header).
- **Private property:** `$user_agent_extension` is `private` rather than `public` to encourage use of the setter method.

## Test plan

- [x] Normal extension is appended after the base UA string
- [x] Whitespace-only input results in no extension appended
- [x] Leading/trailing whitespace is trimmed
- [x] Multiple calls overwrite (last value wins)
- [x] All 34 existing tests continue to pass