### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -3,7 +3,7 @@ namespace DuoAPI;
 
 use DateTime;
 
-const VERSION = "1.2.1-dev";
+const VERSION = "1.3.0";
 const CA_BUNDLE_VERSION = "1.0";
 const INITIAL_BACKOFF_SECONDS = 1;
 const MAX_BACKOFF_SECONDS = 32;


### PR DESCRIPTION
## Summary
- Version bump for the 1.3.0 release containing all CA pinning improvements
- Includes: disable_ca_pinning option (#51), User-Agent reporting (#52), appendToUserAgent() (#53), CURLOPT_CAPATH fix (#54)

## Test plan
- [x] `vendor/bin/phpunit tests/` — all 83 tests pass
- [ ] After merge: tag 1.3.0, create GitHub release, verify Packagist sync